### PR TITLE
Model Test Data Evaluation (Deviation of Prediction) - Group by Episode

### DIFF
--- a/stable_baselines_model_based_rl/dynamic_model_trainer/training.py
+++ b/stable_baselines_model_based_rl/dynamic_model_trainer/training.py
@@ -95,13 +95,15 @@ def __build_and_train_dynamic_model(df: pd.DataFrame, config: Configuration, pat
 
     fig = None
     if config.get('dynamic_model.utility_flags.evaluate_model'):
+        print('Starting model evaluation...')
         dfNet, dfEval = verifier.evaluate_model(model, df, input_col_names, action_col_names,
                                                 target_col_names, lag)
+        print('Starting test data evaluation...')
         dfDiff = verifier.evaluate_model_with_test_data(model, test_data, input_col_names,
                                                         action_col_names, target_col_names, lag)
         if config.get('dynamic_model.utility_flags.plot_results'):
             fig = verifier.plot_results(target_col_names, action_col_names, dfNet, dfEval,
-                                        dfDiff, lag, mean_in, std_in, debug)
+                                        dfDiff, lag, debug)
     model_file_path = None
     if config.get('dynamic_model.utility_flags.save'):
         model_file_path, _ = verifier.save(output_path, model, fig, config, df, debug)

--- a/stable_baselines_model_based_rl/dynamic_model_trainer/verifier.py
+++ b/stable_baselines_model_based_rl/dynamic_model_trainer/verifier.py
@@ -5,59 +5,79 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from stable_baselines_model_based_rl.utils.mean import nested_list_mean
+
 
 def evaluate_model_with_test_data(model, test_data, input_col_names, action_col_names,
                                   target_col_names, lag):
-    eval_test_data = test_data.copy()
-    eval_test_data.describe()
-
-    # FIFO-buffer that keeps the neural state
-    stateBuffer = collections.deque(maxlen=lag)
-
-    # outputs of neural network will be stored here
-    d = {"EPISODE": [], "STEP": []}
-    d.update({col_name: [] for col_name in input_col_names})
-    dfNet = pd.DataFrame(data=d)  # holds predictions
-
-    len_test_data = len(test_data)
-    for i in range(0, len_test_data):
-
-        # estimation of first state
-        if i < lag:
-            state_data = np.float64([eval_test_data[input_col_names[j]].values[i]
-                                     for j in range(0, len(input_col_names))])
-            stateBuffer.append(state_data)
-
-        # predict successor state
-        else:
-
-            # recall of neural network
-            state = np.array([list(stateBuffer)])
-            netOutput = model.predict(np.float64(state))[0]
-
-            # append plotting data
-            dfNet = dfNet.append({target_col_names[j]: netOutput[j]
-                                  for j in range(0, len(target_col_names))}, ignore_index=True)
-
-            # update RNN state
-            dfEval_actions = np.float64([eval_test_data[action_col_name].values[i]
-                                         for action_col_name in action_col_names])
-            stateBuffer.append(np.concatenate((dfEval_actions, netOutput)))
-
-    # first normalize all observation data for comparisons later on
-    normed_target_df = (test_data[target_col_names]-test_data[target_col_names].mean())/test_data[target_col_names].std()
-    normed_target_df = normed_target_df.iloc[1:, :].reset_index(drop=True)
-    # calculate mean diff between normed obs data and prediction for comparison later
-    dfDiff = (normed_target_df - dfNet[target_col_names]).abs()
-    dfSum = dfDiff.sum(axis=1) # sum all columns into one
-    dfMean = dfSum.div(len(target_col_names), axis=0) # divide all row entries by obs
+    """Evaluate the dynamic model with given test data and return average difference per step.
     
-    return dfMean
+    The average (absolute) difference per step is calculated over all episodes of the test data.
+
+    Args:
+        model: Dynamic model to use for evaluating predictions.
+        test_data: Data frame with test data, not (!) grouped by episode yet.
+        input_col_names: Names of the input columns for the model (i.e., action and
+            observations/states).
+        action_col_names: Names of the action columns.
+        target_col_names: Names of the target columns, i.e. state columns (columns predicted by
+            the model)
+        lag: Used window-size / lag by the model.
+
+    Returns:
+        List of average difference per step between prediction and real test data.
+    """
+
+    eval_test_data_grouped = test_data.groupby('EPISODE')
+    episode_diffs = []
+
+    for group in eval_test_data_grouped:
+        eval_test_data = group[1]
+
+        # FIFO-buffer that keeps the neural state
+        stateBuffer = collections.deque(maxlen=lag)
+
+        # storage for outputs (predictions) of neural network
+        dfNet = pd.DataFrame(data={col_name: [] for col_name in target_col_names})
+
+        for i in range(len(eval_test_data)):
+            # estimation of first state
+            if i < lag:
+                state_data = np.float64([eval_test_data[input_col_names[j]].values[i]
+                                        for j in range(len(input_col_names))])
+                stateBuffer.append(state_data)
+                dfNet = dfNet.append({input_col_names[j]: state_data[j]
+                                      for j in range(len(action_col_names), len(input_col_names))},
+                                     ignore_index=True)
+
+            # predict successor state
+            else:
+                # recall of neural network
+                state = np.array([list(stateBuffer)])
+                netOutput = model.predict(np.float64(state))[0]
+
+                # append plotting data
+                dfNet = dfNet.append({target_col_names[j]: netOutput[j]
+                                    for j in range(len(target_col_names))}, ignore_index=True)
+
+                # update RNN state
+                dfEval_actions = np.float64([eval_test_data[action_col_name].values[i]
+                                            for action_col_name in action_col_names])
+                stateBuffer.append(np.concatenate((dfEval_actions, netOutput)))
+
+        # Calculate summed absolute difference/ deviation between prediction and real test
+        # data over all observation columns.
+        dfDiff = (eval_test_data[target_col_names].reset_index(drop=True) - dfNet).abs()
+        dfSum = dfDiff.sum(axis=1)
+        episode_diffs.append(list(dfSum))
+    
+    # average the absolute differences over all test episodes
+    return nested_list_mean(episode_diffs)
 
 
 def evaluate_model(model, data_frame, input_col_names, action_col_names, target_col_names, lag):
     """
-    Measures model quality and displays plotted results on demand
+    Evaluate a given model against the longest episode of the given data_frame.
 
     Args:
         model: Model
@@ -67,17 +87,14 @@ def evaluate_model(model, data_frame, input_col_names, action_col_names, target_
         target_col_names: Names of the targets
         lag: Number of past time steps that are taken into account
 
-    Todo:
-        fix plotting error: ValueError: x and y must have same first dimension, but
-            have shapes (0,) and (64,)
-        plot actions for different action spaces
+    Returns:
+        dfNet: Predictions of the model.
+        dfEval: DataFrame containing the longest episode of the given data_frame. This is the
+            episode the model was evaluated against.
     """
 
     row_max_steps = data_frame.loc[data_frame['STEP'].idxmax()]
-    print(row_max_steps)
-
     dfEval = data_frame[data_frame.EPISODE == row_max_steps.EPISODE]
-    dfEval.describe()
 
     # FIFO-buffer that keeps the neural state
     stateBuffer = collections.deque(maxlen=lag)
@@ -117,15 +134,14 @@ def evaluate_model(model, data_frame, input_col_names, action_col_names, target_
     return dfNet, dfEval
 
 
-def plot_results(target_col_names, action_col_names, dfNet, dfEval, dfDiff,
-                 window_size, mean, std, debug):
+def plot_results(target_col_names, action_col_names, dfNet, dfEval, dfDiff, window_size, debug):
     # the two for additional plots 1. std and 2. for overall training deviation
     plot_count = len(target_col_names) + 2
     fig, axs = plt.subplots(plot_count, 1, figsize=(10, 20))
 
     for action in action_col_names:
         axs[0].plot(range(len(dfNet)), dfEval[action].values[window_size:],
-                                   label=action)
+                    label=action)
     axs[0].grid()
     axs[0].legend(loc="best")
 
@@ -139,11 +155,9 @@ def plot_results(target_col_names, action_col_names, dfNet, dfEval, dfDiff,
         axs[i+1].legend(loc="best")
 
     # plot std & mean
-    axs[plot_count-1].plot(range(len(dfDiff)), dfDiff.values,
-                                   label='absolute deviation from training')
+    axs[plot_count-1].plot(range(len(dfDiff)), dfDiff, label='absolute deviation from training')
     axs[plot_count-1].grid()
     axs[plot_count-1].legend(loc="best")
-    # axs[len(input_col_names)+1].errorbar(range(len(mean)), mean, std, linestyle='None', marker='^')
     
     if debug:
         plt.show()

--- a/stable_baselines_model_based_rl/utils/mean.py
+++ b/stable_baselines_model_based_rl/utils/mean.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+def nested_list_mean(two_d_array):
+    """Average 2D array to 1D array with averaged columns, regardless of their dimension."""
+    output = []
+    maximum = 0
+    # find max index of all nested lists
+    for lst in two_d_array:
+        maximum = max(maximum, len(lst))
+    for index in range(maximum):
+        temp = []
+        for lst in two_d_array:
+            if index < len(lst):
+                temp.append(lst[index])
+        output.append(np.nanmean(temp))
+    return output


### PR DESCRIPTION
Aktuell wird die absolute Differenz zwischen Prediction und echten Test-Daten über alle Episoden hinweg berechnet und der Plot hat 500 Items auf der X-Achse, obwohl die längste Episode nur 80 Steps hat (im Beispiel):

![image](https://user-images.githubusercontent.com/38379512/133648196-346c4448-93bb-4a0c-bf98-54b2d6d59e4e.png)

---

Nachdem die Evaluation auf gruppierten Daten (nach Episode) ausgeführt wird, sieht der Graph so aus. Die Anzahl der Steps entspricht jetzt der Anzahl der Steps in der längsten Episode aus den Test Daten (die kann natürlich auch etwas kürzer sein, als die längste Episode die beim Evaluieren des Models verwendet wird):

![image](https://user-images.githubusercontent.com/38379512/133648537-ea426314-a52e-47d4-9b49-d892b4739d34.png)